### PR TITLE
start publish / deployment on tag push directly

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,8 +4,9 @@
 name: Upload Python Package
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - v*
 
 jobs:
   deploy:


### PR DESCRIPTION
This is an example of how you could trigger the "python package publish" workflow directly from a new tag.
The tag needs to match this expression `v*`.

I'm not sure which method is preferred here, but this allows anyone, who can push a new tag to create a published release straight from the commandline.