### PR TITLE
fix clusterTolayer error in debug mode

### DIFF
--- a/src/lib/components/GeoJSON.react.js
+++ b/src/lib/components/GeoJSON.react.js
@@ -150,7 +150,7 @@ GeoJSON.propTypes = {
     /**
      * Function that determines how a cluster is drawn.
      */
-    clusterToLayer: PropTypes.string,
+    clusterToLayer: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 
     /**
      * If true, markers that are not resolved at max zoom level will be spiderfied on click.


### PR DESCRIPTION
The `clusterTolayer` property is not simply a string but an object (e.g. `{"variable": "dlx.scatter.clusterToLayer"}`).

This modification prevents the Dash server in debug mode to raise an error: ```Invalid argument `clusterToLayer` passed into GeoJSON```

The issue related to this PR is #82.