### PR TITLE
Invalidate size when map size changes

### DIFF
--- a/src/lib/components/Map.react.js
+++ b/src/lib/components/Map.react.js
@@ -15,6 +15,18 @@ export default class Map extends Component {
     constructor(props) {
         super(props);
         this.myRef = React.createRef();  // Create reference to be used for map object
+
+        this.resizeObserver = new ResizeObserver((entries) => {
+            // We can refer directly to the leafletElement since every Map component
+            // gets its own ResizeObserver
+            this.myRef.current.leafletElement.invalidateSize();
+        });
+    }
+
+    componentDidMount() {
+        // Observe the map's container DOM element once the component
+        // is mounted to the page
+        this.resizeObserver.observe(this.myRef.current.container);
     }
 
     render() {
@@ -405,5 +417,3 @@ Map.propTypes = {
     location_lat_lon_acc: PropTypes.arrayOf(PropTypes.number)
 
 };
-
-


### PR DESCRIPTION
When a `dash-leaflet` map component's physical size is changed by altering its CSS (as opposed to e.g. resizing the browser window), the `invalidateSize()` method is not invoked. If the map is enlarged, tiles for the rest of extra space will not be loaded. This pull request fixes this issue by creating a `ResizeObserver` for each map component and then observing its container.  